### PR TITLE
Implementação de suporte a environment via JVM Arguments

### DIFF
--- a/src/main/java/br/com/pjbank/sdk/api/PJBankClient.java
+++ b/src/main/java/br/com/pjbank/sdk/api/PJBankClient.java
@@ -8,7 +8,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.*;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.json.JSONObject;
 
 import java.io.IOException;
 
@@ -28,7 +27,7 @@ public class PJBankClient {
         if (StringUtils.isBlank(endPoint))
             throw new IllegalArgumentException("Endpoint não informado");
 
-        this.absolutePath = PJBankConfig.apiBaseUrl.concat(endPoint);
+        this.absolutePath = PJBankConfig.getApiBaseUrl().concat(endPoint);
     }
 
     /**

--- a/src/main/java/br/com/pjbank/sdk/api/PJBankConfig.java
+++ b/src/main/java/br/com/pjbank/sdk/api/PJBankConfig.java
@@ -9,7 +9,12 @@ public class PJBankConfig {
     /**
      * URL base da API
      */
-    public final static String apiBaseUrl = "https://api.pjbank.com.br/";
+    private final static String apiBaseUrlProducao = "https://api.pjbank.com.br/";
+
+    /**
+     * URL base da API
+     */
+    private final static String apiBaseUrlSandbox = "https://sandbox.pjbank.com.br/";
 
     /**
      * Versão da API a ser consumida pelo SDK
@@ -27,4 +32,16 @@ public class PJBankConfig {
      * Content-type padrão com MIME-type que o client utilizará
      */
     public final static String contentType = "application/json";
+
+    /**
+     * Retorna a URL da API baseada no valor da variável de JVM "pjbank-env". Caso não haja valor definido, será usado o
+     * ambiente dev/sandbox por padrão.
+     * @return String
+     */
+    public static String getApiBaseUrl() {
+        if ("dev".equals(System.getProperty("pjbank-env")))
+            return PJBankConfig.apiBaseUrlSandbox;
+        else
+            return PJBankConfig.apiBaseUrlProducao;
+    }
 }

--- a/src/test/java/br/com/pjbank/sdk/api/PJBankClientTest.java
+++ b/src/test/java/br/com/pjbank/sdk/api/PJBankClientTest.java
@@ -37,7 +37,8 @@ public class PJBankClientTest {
         PJBankClient pjBankClient = new PJBankClient(endPoint);
         HttpGet client = pjBankClient.getHttpGetClient();
 
-        String urlEsperado = "https://api.pjbank.com.br/".concat(endPoint);
+        String urlBase = "dev".equals(System.getProperty("pjbank-env")) ? "https://sandbox.pjbank.com.br/" : "https://api.pjbank.com.br/";
+        String urlEsperado = urlBase.concat(endPoint);
         String acceptHeaderEsperado = "application/json";
         String contentTypeHeaderEsperado = "application/json";
 
@@ -52,7 +53,8 @@ public class PJBankClientTest {
         PJBankClient pjBankClient = new PJBankClient(endPoint);
         HttpPost client = pjBankClient.getHttpPostClient();
 
-        String urlEsperado = "https://api.pjbank.com.br/".concat(endPoint);
+        String urlBase = "dev".equals(System.getProperty("pjbank-env")) ? "https://sandbox.pjbank.com.br/" : "https://api.pjbank.com.br/";
+        String urlEsperado = urlBase.concat(endPoint);
         String acceptHeaderEsperado = "application/json";
         String contentTypeHeaderEsperado = "application/json";
 
@@ -67,7 +69,8 @@ public class PJBankClientTest {
         PJBankClient pjBankClient = new PJBankClient(endPoint);
         HttpPut client = pjBankClient.getHttpPutClient();
 
-        String urlEsperado = "https://api.pjbank.com.br/".concat(endPoint);
+        String urlBase = "dev".equals(System.getProperty("pjbank-env")) ? "https://sandbox.pjbank.com.br/" : "https://api.pjbank.com.br/";
+        String urlEsperado = urlBase.concat(endPoint);
         String acceptHeaderEsperado = "application/json";
         String contentTypeHeaderEsperado = "application/json";
 
@@ -82,7 +85,8 @@ public class PJBankClientTest {
         PJBankClient pjBankClient = new PJBankClient(endPoint);
         HttpDelete client = pjBankClient.getHttpDeleteClient();
 
-        String urlEsperado = "https://api.pjbank.com.br/".concat(endPoint);
+        String urlBase = "dev".equals(System.getProperty("pjbank-env")) ? "https://sandbox.pjbank.com.br/" : "https://api.pjbank.com.br/";
+        String urlEsperado = urlBase.concat(endPoint);
         String acceptHeaderEsperado = "application/json";
         String contentTypeHeaderEsperado = "application/json";
 


### PR DESCRIPTION
Adicionado suporte para definição de ambientes:
- Produção (default): https://api.pjbank.com.br;
- Dev/Sandbox (dev): https://sandbox.pjbank.com.br.

Para definir que deseja utilizar o ambiente Sandbox, basta adicionar o seguinte argumento à inicialização da JVM:
-Dpjbank-env=dev

Por default, a princípio, será utilizado produção visto que o Sandbox será utilizado em casos específicos e somente durante desenvolvimento (cujo desenvolvedor tem total acesso para adicionar em seu ambiente/JVM).