### PR TITLE
Implementação de listagem de anexos de transação com ou sem filtragem por tipo

### DIFF
--- a/src/main/java/br/com/pjbank/sdk/contadigital/ContaDigitalManager.java
+++ b/src/main/java/br/com/pjbank/sdk/contadigital/ContaDigitalManager.java
@@ -521,7 +521,7 @@ public class ContaDigitalManager extends PJBankAuthenticatedService {
     }
 
     /**
-     * Realiza a adição ou edição da URL que deve ser utilizada pelos webhooks da Conta Digital
+     * Retorna a lista de anexos de uma transação com ou sem filtro de tipo
      * @param idTransacao: Código da transação à ser consultada
      * @param tipoAnexo: Tipo de anexo à ser retornado
      * @return boolean

--- a/src/main/java/br/com/pjbank/sdk/enums/FormatoArquivo.java
+++ b/src/main/java/br/com/pjbank/sdk/enums/FormatoArquivo.java
@@ -1,0 +1,24 @@
+package br.com.pjbank.sdk.enums;
+
+public enum FormatoArquivo {
+    JPEG("image/jpeg"), PDF("application/pdf"), PNG("image/png");
+
+    private String name;
+
+    FormatoArquivo(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public static FormatoArquivo fromString(String name) {
+        for (FormatoArquivo obj : FormatoArquivo.values()) {
+            if (obj.name.equalsIgnoreCase(name)) {
+                return obj;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/br/com/pjbank/sdk/enums/TipoAnexo.java
+++ b/src/main/java/br/com/pjbank/sdk/enums/TipoAnexo.java
@@ -1,0 +1,29 @@
+package br.com.pjbank.sdk.enums;
+
+public enum TipoAnexo {
+    BOLETO("boleto"),
+    COMPROVANTE("comprovante"),
+    FATURA("fatura"),
+    OUTROS("outros"),
+    NOTAFISCAL("notafiscal"),
+    PROPOSTA("proposta");
+
+    private String name;
+
+    TipoAnexo(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public static TipoAnexo fromString(String name) {
+        for (TipoAnexo obj : TipoAnexo.values()) {
+            if (obj.name.equalsIgnoreCase(name)) {
+                return obj;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/br/com/pjbank/sdk/models/contadigital/AnexoTransacao.java
+++ b/src/main/java/br/com/pjbank/sdk/models/contadigital/AnexoTransacao.java
@@ -1,12 +1,13 @@
 package br.com.pjbank.sdk.models.contadigital;
 
 import br.com.pjbank.sdk.enums.FormatoArquivo;
+import br.com.pjbank.sdk.enums.TipoAnexo;
 
 import java.util.Date;
 
 public class AnexoTransacao {
     private String url;
-    private String tipo;
+    private TipoAnexo tipo;
     private String nome;
     private FormatoArquivo formato;
     private long tamanho;
@@ -15,7 +16,7 @@ public class AnexoTransacao {
     public AnexoTransacao() {
     }
 
-    public AnexoTransacao(String url, String tipo, String nome, FormatoArquivo formato, long tamanho, Date data) {
+    public AnexoTransacao(String url, TipoAnexo tipo, String nome, FormatoArquivo formato, long tamanho, Date data) {
         this.url = url;
         this.tipo = tipo;
         this.nome = nome;
@@ -32,11 +33,11 @@ public class AnexoTransacao {
         this.url = url;
     }
 
-    public String getTipo() {
+    public TipoAnexo getTipo() {
         return tipo;
     }
 
-    public void setTipo(String tipo) {
+    public void setTipo(TipoAnexo tipo) {
         this.tipo = tipo;
     }
 

--- a/src/main/java/br/com/pjbank/sdk/models/contadigital/AnexoTransacao.java
+++ b/src/main/java/br/com/pjbank/sdk/models/contadigital/AnexoTransacao.java
@@ -1,0 +1,74 @@
+package br.com.pjbank.sdk.models.contadigital;
+
+import br.com.pjbank.sdk.enums.FormatoArquivo;
+
+import java.util.Date;
+
+public class AnexoTransacao {
+    private String url;
+    private String tipo;
+    private String nome;
+    private FormatoArquivo formato;
+    private long tamanho;
+    private Date data;
+
+    public AnexoTransacao() {
+    }
+
+    public AnexoTransacao(String url, String tipo, String nome, FormatoArquivo formato, long tamanho, Date data) {
+        this.url = url;
+        this.tipo = tipo;
+        this.nome = nome;
+        this.formato = formato;
+        this.tamanho = tamanho;
+        this.data = data;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(String tipo) {
+        this.tipo = tipo;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public FormatoArquivo getFormato() {
+        return formato;
+    }
+
+    public void setFormato(FormatoArquivo formato) {
+        this.formato = formato;
+    }
+
+    public long getTamanho() {
+        return tamanho;
+    }
+
+    public void setTamanho(long tamanho) {
+        this.tamanho = tamanho;
+    }
+
+    public Date getData() {
+        return data;
+    }
+
+    public void setData(Date data) {
+        this.data = data;
+    }
+}

--- a/src/test/java/br/com/pjbank/sdk/contadigital/ContaDigitalManagerTest.java
+++ b/src/test/java/br/com/pjbank/sdk/contadigital/ContaDigitalManagerTest.java
@@ -1,11 +1,13 @@
 package br.com.pjbank.sdk.contadigital;
 
 import br.com.pjbank.sdk.enums.FormatoExtrato;
+import br.com.pjbank.sdk.enums.TipoAnexo;
 import br.com.pjbank.sdk.enums.TipoConta;
 import br.com.pjbank.sdk.exceptions.PJBankException;
 import br.com.pjbank.sdk.models.common.Boleto;
 import br.com.pjbank.sdk.models.contadigital.*;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -404,6 +406,43 @@ public class ContaDigitalManagerTest {
     public void manageWebhookURL() throws IOException, JSONException, PJBankException {
         ContaDigitalManager contaDigitalManager = new ContaDigitalManager(this.credencial, this.chave);
 
-        contaDigitalManager.manageWebhookURL("https://pjbank.com.br");
+        Assert.assertTrue(contaDigitalManager.manageWebhookURL("https://pjbank.com.br"));
+    }
+
+    @Test
+    public void getTransactionFilesSemTipoEspecificado() throws IOException, JSONException, URISyntaxException, ParseException, PJBankException {
+        ContaDigitalManager contaDigitalManager = new ContaDigitalManager("eb2af021c5e2448c343965a7a80d7d090eb64164", "a834d47e283dd12f50a1b3a771603ae9dfd5a32c");
+
+        List<AnexoTransacao> anexosTransacao = contaDigitalManager.getTransactionFiles("1000000001259", null);
+
+        // O teste só será executado caso haja algum anexo na transação, do contrário não há como testar
+        if (anexosTransacao.size() > 0) {
+            AnexoTransacao anexoTransacao = anexosTransacao.get(0);
+            Assert.assertThat(anexoTransacao.getUrl(), not(is(emptyOrNullString())));
+            Assert.assertThat(anexoTransacao.getTipo(), not(is(nullValue())));
+            Assert.assertThat(anexoTransacao.getNome(), not(is(emptyOrNullString())));
+            Assert.assertThat(anexoTransacao.getFormato(), not(is(nullValue())));
+            Assert.assertThat(String.valueOf(anexoTransacao.getTamanho()), not(is(emptyOrNullString())));
+            Assert.assertThat(anexoTransacao.getData(), not(is(nullValue())));
+        }
+    }
+
+    @Test
+    public void getTransactionFilesComTipoEspecificado() throws IOException, JSONException, URISyntaxException, ParseException, PJBankException {
+        ContaDigitalManager contaDigitalManager = new ContaDigitalManager("eb2af021c5e2448c343965a7a80d7d090eb64164", "a834d47e283dd12f50a1b3a771603ae9dfd5a32c");
+
+        List<AnexoTransacao> anexosTransacao = contaDigitalManager.getTransactionFiles("1000000001259", TipoAnexo.NOTAFISCAL);
+
+        // O teste só será executado caso haja algum anexo na transação, do contrário não há como testar
+        if (anexosTransacao.size() > 0) {
+            AnexoTransacao anexoTransacao = anexosTransacao.get(0);
+            Assert.assertThat(anexoTransacao.getUrl(), not(is(emptyOrNullString())));
+            Assert.assertThat(anexoTransacao.getTipo(), not(is(nullValue())));
+            Assert.assertEquals(TipoAnexo.NOTAFISCAL, anexoTransacao.getTipo());
+            Assert.assertThat(anexoTransacao.getNome(), not(is(emptyOrNullString())));
+            Assert.assertThat(anexoTransacao.getFormato(), not(is(nullValue())));
+            Assert.assertThat(String.valueOf(anexoTransacao.getTamanho()), not(is(emptyOrNullString())));
+            Assert.assertThat(anexoTransacao.getData(), not(is(nullValue())));
+        }
     }
 }


### PR DESCRIPTION
Titulo: Implementação de listagem de anexos de transação com ou sem filtragem por tipo
Descrição: Implementação de listagem de anexos de transação com ou sem filtragem por tipo 

### Changelog: 

 * Implementado método getTransactionFiles cujo recebe o ID da Transação para ser consultada e, se desejada filtragem, o tipo dos anexos que devem ser retornados.
 * Criação de enum para definição de possíveis tipos de anexos;
 * Criação de enum para definição de possíveis formatos de arquivos;
