### PR TITLE
Ajustes para não quebrar teste caso a busca por arquivos da transação retorne vazio (status 404 no corpo)

### DIFF
--- a/src/main/java/br/com/pjbank/sdk/contadigital/ContaDigitalManager.java
+++ b/src/main/java/br/com/pjbank/sdk/contadigital/ContaDigitalManager.java
@@ -542,8 +542,14 @@ public class ContaDigitalManager extends PJBankAuthenticatedService {
 
         String response = EntityUtils.toString(client.doRequest(httpGet).getEntity());
 
-        JSONArray responseArray = new JSONArray(response);
         List<AnexoTransacao> anexosTransacao = new ArrayList<>();
+
+        JSONObject responseObject = new JSONObject(response);
+        if (responseObject.has("status") && responseObject.getString("status").equals("404")) {
+            return anexosTransacao;
+        }
+
+        JSONArray responseArray = new JSONArray(response);
         DateFormat dateFormat = new SimpleDateFormat("MM/dd/yyyy");
 
         for(int i = 0; i < responseArray.length(); i++) {


### PR DESCRIPTION
Titulo: Ajustes para não quebrar teste caso a busca por arquivos da transação retorne vazio (status 404 no corpo)
Descrição: Ajustes para não quebrar teste caso a busca por arquivos da transação retorne vazio (status 404 no corpo) 

### Changelog: 

 * Foi adicionada validação no corpo do método para caso no corpo do retorno o status seja 404 (enquanto no header seja 200), seja retornado um array vazio (evitando erro de parse no new JSONArray)