### PR TITLE
Limpando \n antes de instanciar JSON em casos de erro (mutex)

### DIFF
--- a/src/main/java/br/com/pjbank/sdk/exceptions/PJBankExceptionHandler.java
+++ b/src/main/java/br/com/pjbank/sdk/exceptions/PJBankExceptionHandler.java
@@ -14,7 +14,7 @@ public class PJBankExceptionHandler {
      * @return PJBankException: Exceção contendo o status e a mensagem formatada retornada pela API
      */
     public static PJBankException handleFromJSONResponse(String response){
-        JSONObject responseObject = new JSONObject(response);
+        JSONObject responseObject = new JSONObject(response.replace("\n", ""));
         return new PJBankException(responseObject.has("status") ? responseObject.getInt("status") : 500,
                                     responseObject.has("msg") ? responseObject.getString("msg") :
                                     responseObject.has("message") ? responseObject.getString("message") : "undefined");


### PR DESCRIPTION
Titulo: Limpando \n antes de instanciar JSON em casos de erro (mutex)
Descrição: Limpando \n antes de instanciar JSON em casos de erro (mutex) 

### Changelog: 

 * Remover \n que o ERP retorna em erros de Mutex e geram erro ao tentar converter para JSON
